### PR TITLE
[Buck] [HACK] Introduce hacky logic for Buck build

### DIFF
--- a/src/com/facebook/buck/cxx/CxxLibraryDescription.java
+++ b/src/com/facebook/buck/cxx/CxxLibraryDescription.java
@@ -1226,6 +1226,7 @@ public class CxxLibraryDescription implements
     // used otherwise.
     public Optional<SourcePath> bridgingHeader;
     public Optional<String> moduleName;
+    public Optional<String> swiftProcessScript;
 
     /**
      * @return C/C++ deps which are propagated to dependents.

--- a/src/com/facebook/buck/swift/SwiftDescriptions.java
+++ b/src/com/facebook/buck/swift/SwiftDescriptions.java
@@ -77,6 +77,8 @@ public class SwiftDescriptions {
 
     boolean isCompanionTarget = buildTarget.getFlavors().contains(SWIFT_COMPANION_FLAVOR);
     output.preferredLinkage = isCompanionTarget ? Optional.of(STATIC) : args.preferredLinkage;
+
+    output.swiftProcessScript = args.swiftProcessScript;
   }
 
   static String toSwiftHeaderName(String moduleName) {

--- a/src/com/facebook/buck/swift/SwiftLibraryDescription.java
+++ b/src/com/facebook/buck/swift/SwiftLibraryDescription.java
@@ -258,7 +258,8 @@ public class SwiftLibraryDescription implements
           args.srcs,
           args.compilerFlags,
           args.enableObjcInterop,
-          args.bridgingHeader);
+          args.bridgingHeader,
+          args.swiftProcessScript);
     }
 
     // Otherwise, we return the generic placeholder of this library.
@@ -459,6 +460,8 @@ public class SwiftLibraryDescription implements
 
     public ImmutableMap<Path, SourcePath> headers = ImmutableMap.of();
     public ImmutableMap<Path, SourcePath> exportedHeaders = ImmutableMap.of();
+
+    public Optional<String> swiftProcessScript;
   }
 
 }


### PR DESCRIPTION
The way Buck generate `-Swift.h` usually introduce some problems, e.g. `PromiseKit` will break if the script importing `PromiseKit-Bridging-Header.h`, however, it will work if it import `<PromiseKit/PromiseKit.h>`.

The same problem also happen in files under `ios/src`.

To fix the problem, we are not able fix Buck because its not supporting `-import-underlying-module`. This PR is a *VERY HACKY* logic, which introduce one more step in `SwiftCompile`, and replace the import logic in generated `-Swift.h` logic.

@seanabraham @fkorotkov PTAL and let me know how do you guys think