### PR TITLE
Do not include Target-Swift.h in umbrella header

### DIFF
--- a/src/com/facebook/buck/apple/clang/UmbrellaHeader.java
+++ b/src/com/facebook/buck/apple/clang/UmbrellaHeader.java
@@ -30,6 +30,11 @@ public class UmbrellaHeader {
   public String render() {
     return headerNames
         .stream()
+        // Remove the Target-Swift.h header file from the list of header names.
+        // The umbrella header should not import the generated Objective-C header.
+        // It is the job of the module map to make sure that Swift code is accessible
+        // to Objective-C via the Target-Swift.h header file.
+        .filter(x -> !x.equals(String.format("%s-Swift.h", targetName)))
         .map(x -> String.format("#import <%s/%s>\n", targetName, x))
         .reduce("", String::concat);
   }


### PR DESCRIPTION
This should hopefully remove the `#import <Target-Swift.h>` from the `Target.h` umbrella file for each module. I was able to build/test this locally on https://github.com/airbnb/BuckSample, and it worked!

Note that the target of this PR is `buck-tiger-team`, which was branched from `sh/airbnb-tracking`