### PR TITLE
Revert "[iOS][Umbrella] Add support for umbrella header arg to apple_library"

### DIFF
--- a/src/com/facebook/buck/apple/AppleLibraryDescription.java
+++ b/src/com/facebook/buck/apple/AppleLibraryDescription.java
@@ -710,7 +710,6 @@ public class AppleLibraryDescription
         ruleFinder,
         HeaderMode.SYMLINK_TREE_WITH_MODULEMAP,
         headers.build(),
-        args.getUmbrellaHeader(),
         HeaderVisibility.PUBLIC);
   }
 
@@ -739,8 +738,7 @@ public class AppleLibraryDescription
         ruleFinder,
         root,
         headers,
-        HeaderMode.SYMLINK_TREE_WITH_MODULEMAP,
-        args.getUmbrellaHeader());
+        HeaderMode.SYMLINK_TREE_WITH_MODULEMAP);
   }
 
   <U> Optional<U> createMetadataForLibrary(

--- a/src/com/facebook/buck/apple/AppleNativeTargetDescriptionArg.java
+++ b/src/com/facebook/buck/apple/AppleNativeTargetDescriptionArg.java
@@ -17,7 +17,6 @@
 package com.facebook.buck.apple;
 
 import com.facebook.buck.core.exceptions.HumanReadableException;
-import com.facebook.buck.core.sourcepath.SourcePath;
 import com.facebook.buck.cxx.CxxLibraryDescription;
 import com.facebook.buck.swift.SwiftCommonArg;
 import com.google.common.collect.ImmutableMap;
@@ -32,8 +31,6 @@ public interface AppleNativeTargetDescriptionArg
   ImmutableSortedMap<String, ImmutableMap<String, String>> getConfigs();
 
   Optional<String> getHeaderPathPrefix();
-
-  Optional<SourcePath> getUmbrellaHeader();
 
   @Value.Default
   default boolean isModular() {

--- a/src/com/facebook/buck/apple/clang/ModuleMap.java
+++ b/src/com/facebook/buck/apple/clang/ModuleMap.java
@@ -19,8 +19,6 @@ package com.facebook.buck.apple.clang;
 import com.google.common.base.Objects;
 import org.stringtemplate.v4.ST;
 
-import java.util.Optional;
-
 /**
  * Generate a modulemap, with optional references to a swift generated swift header.
  *
@@ -37,12 +35,11 @@ public class ModuleMap {
 
   private final SwiftMode swiftMode;
   private final String moduleName;
-  private final Optional<String> umbrellaHeader;
 
   private String generatedModule;
   private static final String template =
       "module <module_name> {\n"
-          + "    umbrella header \"<module_header>\"\n"
+          + "    umbrella header \"<module_name>.h\"\n"
           + "\n"
           + "    export *\n"
           + "    module * { export * }\n"
@@ -62,24 +59,16 @@ public class ModuleMap {
           + "<endif>"
           + "\n";
 
-  public ModuleMap(String moduleName, SwiftMode swiftMode, Optional<String> umbrellaHeader) {
+  public ModuleMap(String moduleName, SwiftMode swiftMode) {
     this.moduleName = moduleName;
     this.swiftMode = swiftMode;
-    this.umbrellaHeader = umbrellaHeader;
   }
 
   public String render() {
-    String moduleHeader;
-    if (umbrellaHeader.isPresent()) {
-      moduleHeader = umbrellaHeader.get();
-    } else {
-      moduleHeader = moduleName + ".h";
-    }
     if (this.generatedModule == null) {
       ST st =
           new ST(template)
               .add("module_name", moduleName)
-              .add("module_header", moduleHeader)
               .add("include_swift_header", false)
               .add("exclude_swift_header", false);
       switch (swiftMode) {

--- a/src/com/facebook/buck/cxx/CxxBinaryFactory.java
+++ b/src/com/facebook/buck/cxx/CxxBinaryFactory.java
@@ -204,7 +204,6 @@ public class CxxBinaryFactory {
         cxxPlatform,
         CxxDescriptionEnhancer.parseHeaders(
             buildTarget, graphBuilder, ruleFinder, pathResolver, Optional.of(cxxPlatform), args),
-        Optional.empty(),
         HeaderVisibility.PRIVATE,
         true);
   }

--- a/src/com/facebook/buck/cxx/CxxDescriptionEnhancer.java
+++ b/src/com/facebook/buck/cxx/CxxDescriptionEnhancer.java
@@ -151,7 +151,6 @@ public class CxxDescriptionEnhancer {
       SourcePathRuleFinder ruleFinder,
       HeaderMode mode,
       ImmutableMap<Path, SourcePath> headers,
-      Optional<SourcePath> umbrellaHeader,
       HeaderVisibility headerVisibility,
       Flavor... flavors) {
     BuildTarget headerSymlinkTreeTarget =
@@ -160,15 +159,13 @@ public class CxxDescriptionEnhancer {
     Path headerSymlinkTreeRoot =
         CxxDescriptionEnhancer.getHeaderSymlinkTreePath(
             projectFilesystem, buildTarget, headerVisibility, flavors);
-
     return CxxPreprocessables.createHeaderSymlinkTreeBuildRule(
         headerSymlinkTreeTarget,
         projectFilesystem,
         ruleFinder,
         headerSymlinkTreeRoot,
         headers,
-        mode,
-        umbrellaHeader);
+        mode);
   }
 
   public static HeaderSymlinkTree createHeaderSymlinkTree(
@@ -178,7 +175,6 @@ public class CxxDescriptionEnhancer {
       BuildRuleResolver resolver,
       CxxPlatform cxxPlatform,
       ImmutableMap<Path, SourcePath> headers,
-      Optional<SourcePath> umbrellaHeader,
       HeaderVisibility headerVisibility,
       boolean shouldCreateHeadersSymlinks) {
     return createHeaderSymlinkTree(
@@ -187,7 +183,6 @@ public class CxxDescriptionEnhancer {
         ruleFinder,
         getHeaderModeForPlatform(resolver, cxxPlatform, shouldCreateHeadersSymlinks),
         headers,
-        umbrellaHeader,
         headerVisibility,
         cxxPlatform.getFlavor());
   }
@@ -217,7 +212,6 @@ public class CxxDescriptionEnhancer {
                     graphBuilder,
                     cxxPlatform,
                     headers,
-                    Optional.empty(),
                     headerVisibility,
                     shouldCreateHeadersSymlinks));
   }

--- a/src/com/facebook/buck/cxx/CxxLibraryFactory.java
+++ b/src/com/facebook/buck/cxx/CxxLibraryFactory.java
@@ -751,7 +751,6 @@ public class CxxLibraryFactory {
         cxxPlatform,
         CxxDescriptionEnhancer.parseHeaders(
             buildTarget, graphBuilder, ruleFinder, pathResolver, Optional.of(cxxPlatform), args),
-        Optional.empty(),
         HeaderVisibility.PRIVATE,
         shouldCreatePrivateHeaderSymlinks);
   }
@@ -772,7 +771,6 @@ public class CxxLibraryFactory {
         mode,
         CxxDescriptionEnhancer.parseExportedHeaders(
             buildTarget, graphBuilder, ruleFinder, pathResolver, Optional.empty(), args),
-        Optional.empty(),
         HeaderVisibility.PUBLIC);
   }
 
@@ -795,7 +793,6 @@ public class CxxLibraryFactory {
         cxxPlatform,
         CxxDescriptionEnhancer.parseExportedPlatformHeaders(
             buildTarget, graphBuilder, ruleFinder, pathResolver, cxxPlatform, args),
-        Optional.empty(),
         HeaderVisibility.PUBLIC,
         shouldCreatePublicHeaderSymlinks);
   }

--- a/src/com/facebook/buck/cxx/CxxPreprocessables.java
+++ b/src/com/facebook/buck/cxx/CxxPreprocessables.java
@@ -43,7 +43,6 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Predicate;
 
 public class CxxPreprocessables {
@@ -158,19 +157,12 @@ public class CxxPreprocessables {
       SourcePathRuleFinder ruleFinder,
       Path root,
       ImmutableMap<Path, SourcePath> links,
-      HeaderMode headerMode,
-      Optional<SourcePath> umbrellaHeaderPath) {
+      HeaderMode headerMode) {
     switch (headerMode) {
       case SYMLINK_TREE_WITH_HEADER_MAP:
         return HeaderSymlinkTreeWithHeaderMap.create(target, filesystem, root, links, ruleFinder);
       case SYMLINK_TREE_WITH_MODULEMAP:
-        return HeaderSymlinkTreeWithModuleMap.create(
-            target,
-            filesystem,
-            root,
-            links,
-            ruleFinder,
-            umbrellaHeaderPath);
+        return HeaderSymlinkTreeWithModuleMap.create(target, filesystem, root, links, ruleFinder);
       case HEADER_MAP_ONLY:
         return new DirectHeaderMap(target, filesystem, root, links, ruleFinder);
       default:

--- a/src/com/facebook/buck/cxx/PrebuiltCxxLibraryDescription.java
+++ b/src/com/facebook/buck/cxx/PrebuiltCxxLibraryDescription.java
@@ -175,7 +175,6 @@ public class PrebuiltCxxLibraryDescription
         graphBuilder,
         cxxPlatform,
         parseExportedHeaders(buildTarget, graphBuilder, cxxPlatform, args),
-        Optional.empty(),
         HeaderVisibility.PUBLIC,
         true);
   }

--- a/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
+++ b/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
@@ -2961,10 +2961,10 @@ public class ProjectGenerator {
         boolean containsSwift = !nonSourcePaths.isEmpty();
         if (containsSwift) {
           projectFilesystem.writeContentsToPath(
-              new ModuleMap(moduleName.get(), ModuleMap.SwiftMode.INCLUDE_SWIFT_HEADER, Optional.empty()).render(),
+              new ModuleMap(moduleName.get(), ModuleMap.SwiftMode.INCLUDE_SWIFT_HEADER).render(),
               headerSymlinkTreeRoot.resolve(moduleName.get()).resolve("module.modulemap"));
           projectFilesystem.writeContentsToPath(
-              new ModuleMap(moduleName.get(), ModuleMap.SwiftMode.EXCLUDE_SWIFT_HEADER, Optional.empty()).render(),
+              new ModuleMap(moduleName.get(), ModuleMap.SwiftMode.EXCLUDE_SWIFT_HEADER).render(),
               headerSymlinkTreeRoot.resolve(moduleName.get()).resolve("objc.modulemap"));
 
           Path absoluteModuleRoot =
@@ -2982,7 +2982,7 @@ public class ProjectGenerator {
               getObjcModulemapVFSOverlayLocationFromSymlinkTreeRoot(headerSymlinkTreeRoot));
         } else {
           projectFilesystem.writeContentsToPath(
-              new ModuleMap(moduleName.get(), ModuleMap.SwiftMode.NO_SWIFT, Optional.empty()).render(),
+              new ModuleMap(moduleName.get(), ModuleMap.SwiftMode.NO_SWIFT).render(),
               headerSymlinkTreeRoot.resolve(moduleName.get()).resolve("module.modulemap"));
         }
         Path absoluteModuleRoot =

--- a/src/com/facebook/buck/features/go/CGoLibrary.java
+++ b/src/com/facebook/buck/features/go/CGoLibrary.java
@@ -316,7 +316,6 @@ public class CGoLibrary extends NoopBuildRuleWithDeclaredAndExtraDeps {
         graphBuilder,
         cxxPlatform,
         allHeaders.build(),
-        Optional.empty(),
         HeaderVisibility.PUBLIC,
         true);
   }

--- a/src/com/facebook/buck/features/halide/HalideLibraryDescription.java
+++ b/src/com/facebook/buck/features/halide/HalideLibraryDescription.java
@@ -313,7 +313,6 @@ public class HalideLibraryDescription
           graphBuilder,
           cxxPlatform,
           headersBuilder.build(),
-          Optional.empty(),
           HeaderVisibility.PUBLIC,
           true);
     } else if (flavors.contains(HALIDE_COMPILER_FLAVOR)) {


### PR DESCRIPTION
This reverts commit 479c4cb9449f57471bce6e7e2dc54ea8c0e192e6.

This commit shouldn't be necessary to compile in mixed Swift+ObjC modules. I'm tempted to close this PR out and instead rebase `479c4cb9449f57471bce6e7e2dc54ea8c0e192e6` out of `buck-tiger-team`.

Pros of rebasing the commit out:
* It is easier to rebase against Facebook's `master` branch since we don't have a commit+revert on our tree.

Cons of rebasing the commit out:
* I'd have to force push, and you two would have to reset your local clone's branch to origin.

Feels worth it to me, but I'm curious what your thoughts are @bachand and @fdiaz.