### PR TITLE
Replace "incorrect" types to make project generation work with xcodeproj

### DIFF
--- a/src/com/facebook/buck/apple/xcode/xcodeproj/PBXBuildPhase.java
+++ b/src/com/facebook/buck/apple/xcode/xcodeproj/PBXBuildPhase.java
@@ -54,6 +54,6 @@ public abstract class PBXBuildPhase extends PBXProjectItem {
     s.addField("files", files);
     name.ifPresent(phaseName -> s.addField("name", phaseName));
     runOnlyForDeploymentPostprocessing.ifPresent(
-        runOnly -> s.addField("runOnlyForDeploymentPostprocessing", runOnly ? 1 : 0));
+        runOnly -> s.addField("runOnlyForDeploymentPostprocessing", runOnly ? "1" : "0"));
   }
 }

--- a/src/com/facebook/buck/apple/xcode/xcodeproj/PBXCopyFilesBuildPhase.java
+++ b/src/com/facebook/buck/apple/xcode/xcodeproj/PBXCopyFilesBuildPhase.java
@@ -67,7 +67,7 @@ public class PBXCopyFilesBuildPhase extends PBXBuildPhase {
   @Override
   public void serializeInto(XcodeprojSerializer s) {
     super.serializeInto(s);
-    s.addField("dstSubfolderSpec", dstSubfolderSpec.getDestination().getValue());
+    s.addField("dstSubfolderSpec", String.valueOf(dstSubfolderSpec.getDestination().getValue()));
     s.addField("dstPath", dstSubfolderSpec.getPath().orElse(""));
   }
 }


### PR DESCRIPTION
Buck currently outputs an XML for `project.pbxproj` where `runOnlyForDeploymentPostprocessing` and `dstSubfolderSpec` are treated as `integer`.

```
			<key>runOnlyForDeploymentPostprocessing</key>
			<integer>1</integer>
			<key>dstSubfolderSpec</key>
			<integer>16</integer>
```

When trying to open the `.xcodeproj` file with [xcodeproj](https://github.com/CocoaPods/Xcodeproj) we're getting:

> [Xcodeproj] Type checking error: got `Fixnum` for attribute: Attribute `dstSubfolderSpec` (type: `simple`, classes: `[String]`, owner class: `PBXCopyFilesBuildPhase`)

This [seems to be a bug](https://github.com/CocoaPods/Xcodeproj/issues/475) in xcodeproj itself.

To work around this, I'm forcing these 2 keys to have Strings as values instead of Int. After doing this, `xcodeproj` can succesfully open our project.

cc @dfed @bachand @shepting 