### PR TITLE
Added friend_paths to kotlin_library rule API (#2197)

### DIFF
--- a/docs/rule/kotlin_library.soy
+++ b/docs/rule/kotlin_library.soy
@@ -77,6 +77,15 @@ the <code>resources</code> argument.
 {/call}
 
 {call buck.arg}
+  {param name: 'friend_paths' /}
+  {param default: '[]' /}
+  {param desc}
+  List of source paths to pass into the Kotlin compiler as friend-paths, that is, modules
+  you can have access to internal methods.
+  {/param}
+{/call}
+
+{call buck.arg}
   {param name: 'annotation_processing_tool' /}
   {param default : 'kapt' /}
   {param desc}

--- a/src/com/facebook/buck/jvm/kotlin/KotlinConfiguredCompilerFactory.java
+++ b/src/com/facebook/buck/jvm/kotlin/KotlinConfiguredCompilerFactory.java
@@ -66,6 +66,7 @@ public class KotlinConfiguredCompilerFactory extends ConfiguredCompilerFactory {
     return new KotlincToJarStepFactory(
         kotlinBuckConfig.getKotlinc(),
         kotlinArgs.getExtraKotlincArguments(),
+        kotlinArgs.getFriendPaths(),
         kotlinArgs.getAnnotationProcessingTool().orElse(AnnotationProcessingTool.KAPT),
         extraClasspathProviderSupplier.apply(toolchainProvider),
         getJavac(buildRuleResolver, args),

--- a/src/com/facebook/buck/jvm/kotlin/KotlinLibraryDescription.java
+++ b/src/com/facebook/buck/jvm/kotlin/KotlinLibraryDescription.java
@@ -26,6 +26,7 @@ import com.facebook.buck.core.model.targetgraph.DescriptionWithTargetGraph;
 import com.facebook.buck.core.rules.ActionGraphBuilder;
 import com.facebook.buck.core.rules.BuildRule;
 import com.facebook.buck.core.rules.BuildRuleParams;
+import com.facebook.buck.core.sourcepath.SourcePath;
 import com.facebook.buck.core.toolchain.ToolchainProvider;
 import com.facebook.buck.core.util.immutables.BuckStyleImmutable;
 import com.facebook.buck.io.filesystem.ProjectFilesystem;
@@ -196,6 +197,8 @@ public class KotlinLibraryDescription
     ImmutableList<String> getExtraKotlincArguments();
 
     Optional<AnnotationProcessingTool> getAnnotationProcessingTool();
+
+    ImmutableList<SourcePath> getFriendPaths();
   }
 
   @BuckStyleImmutable

--- a/src/com/facebook/buck/jvm/kotlin/KotlincStep.java
+++ b/src/com/facebook/buck/jvm/kotlin/KotlincStep.java
@@ -165,7 +165,11 @@ public class KotlincStep implements Step {
     builder.add(VERBOSE);
 
     if (!extraArguments.isEmpty()) {
-      builder.addAll(extraArguments);
+      for (String extraArgument : extraArguments) {
+        if (!extraArgument.isEmpty()) {
+          builder.add(extraArgument);
+        }
+      }
     }
 
     return builder.build();

--- a/src/com/facebook/buck/jvm/kotlin/KotlincToJarStepFactory.java
+++ b/src/com/facebook/buck/jvm/kotlin/KotlincToJarStepFactory.java
@@ -24,6 +24,7 @@ import com.facebook.buck.core.model.BuildTarget;
 import com.facebook.buck.core.model.impl.BuildTargetPaths;
 import com.facebook.buck.core.rulekey.AddToRuleKey;
 import com.facebook.buck.core.rulekey.AddsToRuleKey;
+import com.facebook.buck.core.sourcepath.SourcePath;
 import com.facebook.buck.core.sourcepath.resolver.SourcePathResolver;
 import com.facebook.buck.io.BuildCellRelativePath;
 import com.facebook.buck.io.filesystem.FileExtensionMatcher;
@@ -67,6 +68,7 @@ public class KotlincToJarStepFactory extends CompileToJarStepFactory implements 
 
   @AddToRuleKey private final Kotlinc kotlinc;
   @AddToRuleKey private final ImmutableList<String> extraKotlincArguments;
+  @AddToRuleKey private final ImmutableList<SourcePath> friendPaths;
   @AddToRuleKey private final AnnotationProcessingTool annotationProcessingTool;
   @AddToRuleKey private final ExtraClasspathProvider extraClassPath;
   @AddToRuleKey private final Javac javac;
@@ -102,12 +104,14 @@ public class KotlincToJarStepFactory extends CompileToJarStepFactory implements 
   KotlincToJarStepFactory(
       Kotlinc kotlinc,
       ImmutableList<String> extraKotlincArguments,
+      ImmutableList<SourcePath> friendPaths,
       AnnotationProcessingTool annotationProcessingTool,
       ExtraClasspathProvider extraClassPath,
       Javac javac,
       JavacOptions javacOptions) {
     this.kotlinc = kotlinc;
     this.extraKotlincArguments = extraKotlincArguments;
+    this.friendPaths = friendPaths;
     this.annotationProcessingTool = annotationProcessingTool;
     this.extraClassPath = extraClassPath;
     this.javac = javac;
@@ -173,6 +177,8 @@ public class KotlincToJarStepFactory extends CompileToJarStepFactory implements 
               .addAll(kotlinc.getHomeLibraries(buildContext.getSourcePathResolver()))
               .build();
 
+      String friendPathsArg = getFriendsPath(buildContext.getSourcePathResolver(), friendPaths);
+
       if (generatingCode && annotationProcessingTool.equals(AnnotationProcessingTool.KAPT)) {
         addKaptGenFolderStep(
             invokingRule,
@@ -183,6 +189,7 @@ public class KotlincToJarStepFactory extends CompileToJarStepFactory implements 
             pathToSrcsList,
             allClasspaths,
             extraKotlincArguments,
+            friendPathsArg,
             sourcesOutput,
             stubsOutput,
             incrementalDataOutput,
@@ -221,6 +228,7 @@ public class KotlincToJarStepFactory extends CompileToJarStepFactory implements 
               kotlinc.getHomeLibraries(buildContext.getSourcePathResolver()),
               ImmutableList.<String>builder()
                   .addAll(extraKotlincArguments)
+                  .add(friendPathsArg)
                   .add(NO_STDLIB)
                   .add(NO_REFLECT)
                   .add(COMPILER_BUILTINS)
@@ -292,7 +300,8 @@ public class KotlincToJarStepFactory extends CompileToJarStepFactory implements 
       ImmutableSortedSet<Path> sourceFilePaths,
       Path pathToSrcsList,
       Iterable<? extends Path> declaredClasspathEntries,
-      ImmutableList<String> extraArguments,
+      ImmutableList<String> extraKotlincArguments,
+      String friendPathsArg,
       Path kaptGenerated,
       Path stubsOutput,
       Path incrementalData,
@@ -350,7 +359,8 @@ public class KotlincToJarStepFactory extends CompileToJarStepFactory implements 
             kotlinc,
             kotlinc.getHomeLibraries(resolver),
             ImmutableList.<String>builder()
-                .addAll(extraArguments)
+                .addAll(extraKotlincArguments)
+                .add(friendPathsArg)
                 .add(MODULE_NAME)
                 .add(invokingRule.getShortNameAndFlavorPostfix())
                 .add(COMPILER_BUILTINS)
@@ -379,7 +389,8 @@ public class KotlincToJarStepFactory extends CompileToJarStepFactory implements 
             kotlinc,
             kotlinc.getHomeLibraries(resolver),
             ImmutableList.<String>builder()
-                .addAll(extraArguments)
+                .addAll(extraKotlincArguments)
+                .add(friendPathsArg)
                 .add(MODULE_NAME)
                 .add(invokingRule.getShortNameAndFlavorPostfix())
                 .add(COMPILER_BUILTINS)
@@ -441,6 +452,24 @@ public class KotlincToJarStepFactory extends CompileToJarStepFactory implements 
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  private String getFriendsPath(
+      SourcePathResolver sourcePathResolver, ImmutableList<SourcePath> friendPathsSourcePaths) {
+    if (friendPathsSourcePaths.isEmpty()) {
+      return "";
+    }
+
+    // https://youtrack.jetbrains.com/issue/KT-29933
+    ImmutableSortedSet<String> absoluteFriendPaths =
+        ImmutableSortedSet.copyOf(
+            friendPathsSourcePaths
+                .stream()
+                .map(path -> sourcePathResolver.getAbsolutePath(path).toString())
+                .collect(Collectors.toSet()));
+
+    return "-Xfriend-paths="
+        + absoluteFriendPaths.stream().reduce("", (path1, path2) -> path1 + "," + path2);
   }
 
   @Override

--- a/test/com/facebook/buck/jvm/kotlin/KotlinTestIntegrationTest.java
+++ b/test/com/facebook/buck/jvm/kotlin/KotlinTestIntegrationTest.java
@@ -69,4 +69,10 @@ public class KotlinTestIntegrationTest {
     ProcessResult result = workspace.runBuckCommand("test", "//com/example/basic:failing");
     result.assertTestFailure("Test should've failed.");
   }
+
+  @Test
+  public void weCanAccessAnotherModuleInternalModuleByAddingItToFriendPaths() throws Exception {
+    ProcessResult result = workspace.runBuckCommand("test", "//com/example/friend_paths:passing");
+    result.assertSuccess("Build should've succeeded.");
+  }
 }

--- a/test/com/facebook/buck/jvm/kotlin/testdata/kotlin_test_description/com/example/friend_paths/BUCK.fixture
+++ b/test/com/facebook/buck/jvm/kotlin/testdata/kotlin_test_description/com/example/friend_paths/BUCK.fixture
@@ -1,0 +1,23 @@
+kotlin_library(
+    name = "main",
+    srcs = [
+        "Main.kt",
+    ],
+    visibility = [
+        "PUBLIC",
+    ],
+)
+
+kotlin_test(
+    name = "passing",
+    srcs = [
+        "PassingUnitTest.kt",
+    ],
+    friend_paths = [
+        ":main",
+    ],
+    deps = [
+        "buck//third-party/java/junit:junit",
+        ":main",
+    ],
+)

--- a/test/com/facebook/buck/jvm/kotlin/testdata/kotlin_test_description/com/example/friend_paths/Main.kt
+++ b/test/com/facebook/buck/jvm/kotlin/testdata/kotlin_test_description/com/example/friend_paths/Main.kt
@@ -1,0 +1,5 @@
+package com.example.friend_paths
+
+class Main {
+    internal fun main() {}
+}

--- a/test/com/facebook/buck/jvm/kotlin/testdata/kotlin_test_description/com/example/friend_paths/PassingUnitTest.kt
+++ b/test/com/facebook/buck/jvm/kotlin/testdata/kotlin_test_description/com/example/friend_paths/PassingUnitTest.kt
@@ -1,0 +1,14 @@
+package com.example.friend_paths
+
+import org.junit.runners.JUnit4
+import org.junit.runner.RunWith
+import org.junit.Test
+
+@RunWith(JUnit4::class)
+class PassingUnitTests {
+
+    @Test
+    fun testAbleToAccessInternalMethod() {
+        Main().main()
+    }
+}


### PR DESCRIPTION
Summary:
This is a feature of kotlin compiler to allow other modules to access chosen module's internal methods/variables.
This is keen to have a good test coverage on kotlin without exposing your libraries internals
Pull Request resolved: https://github.com/facebook/buck/pull/2197

Reviewed By: styurin

Pulled By: styurin

fbshipit-source-id: 0a969a41b8