### PR TITLE
Support Index generation in Buck

### DIFF
--- a/src/com/facebook/buck/apple/clang/UmbrellaHeader.java
+++ b/src/com/facebook/buck/apple/clang/UmbrellaHeader.java
@@ -28,7 +28,12 @@ public class UmbrellaHeader {
   }
 
   public String render() {
+    String swiftGeneratedHeader = String.format("%s-Swift.h", targetName);
     return headerNames.stream()
+        // Remove the Target-Swift.h header file from the list of header names.
+        // The umbrella header should not import the generated Objective-C header.
+        // It is the job of the module map to make sure that Swift code is accessible
+        .filter(x -> !x.equals(swiftGeneratedHeader))
         .map(x -> String.format("#import <%s/%s>\n", targetName, x))
         .reduce("", String::concat);
   }

--- a/src/com/facebook/buck/apple/xcode/xcodeproj/PBXBuildPhase.java
+++ b/src/com/facebook/buck/apple/xcode/xcodeproj/PBXBuildPhase.java
@@ -54,6 +54,6 @@ public abstract class PBXBuildPhase extends PBXProjectItem {
     s.addField("files", files);
     name.ifPresent(phaseName -> s.addField("name", phaseName));
     runOnlyForDeploymentPostprocessing.ifPresent(
-        runOnly -> s.addField("runOnlyForDeploymentPostprocessing", runOnly ? 1 : 0));
+        runOnly -> s.addField("runOnlyForDeploymentPostprocessing", runOnly ? "1" : "0"));
   }
 }

--- a/src/com/facebook/buck/apple/xcode/xcodeproj/PBXCopyFilesBuildPhase.java
+++ b/src/com/facebook/buck/apple/xcode/xcodeproj/PBXCopyFilesBuildPhase.java
@@ -67,7 +67,7 @@ public class PBXCopyFilesBuildPhase extends PBXBuildPhase {
   @Override
   public void serializeInto(XcodeprojSerializer s) {
     super.serializeInto(s);
-    s.addField("dstSubfolderSpec", dstSubfolderSpec.getDestination().getValue());
+    s.addField("dstSubfolderSpec", String.valueOf(dstSubfolderSpec.getDestination().getValue()));
     s.addField("dstPath", dstSubfolderSpec.getPath().orElse(""));
   }
 }

--- a/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
+++ b/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
@@ -352,7 +352,7 @@ public class ProjectGenerator {
                 cell.getCellProvider()));
     this.buckEventBus = buckEventBus;
 
-    this.projectPath = outputDirectory.resolve(projectName + ".xcodeproj");
+    this.projectPath = outputDirectory.resolve(projectName + "-BUCK.xcodeproj");
     this.pathRelativizer = new PathRelativizer(outputDirectory, this::resolveSourcePath);
     this.sharedLibraryToBundle = sharedLibraryToBundle;
 
@@ -3380,7 +3380,7 @@ public class ProjectGenerator {
   private void writeProjectFile(PBXProject project) throws IOException {
     XcodeprojSerializer serializer = new XcodeprojSerializer(gidGenerator, project);
     NSDictionary rootObject = serializer.toPlist();
-    Path xcodeprojDir = outputDirectory.resolve(projectName + ".xcodeproj");
+    Path xcodeprojDir = outputDirectory.resolve(projectName + "-BUCK.xcodeproj");
     projectFilesystem.mkdirs(xcodeprojDir);
     Path serializedProject = xcodeprojDir.resolve("project.pbxproj");
     String contentsToWrite = rootObject.toXMLPropertyList();

--- a/src/com/facebook/buck/features/apple/project/WorkspaceAndProjectGenerator.java
+++ b/src/com/facebook/buck/features/apple/project/WorkspaceAndProjectGenerator.java
@@ -214,7 +214,7 @@ public class WorkspaceAndProjectGenerator {
       outputDirectory =
           BuildTargetPaths.getGenPath(rootCell.getFilesystem(), workspaceBuildTarget, "%s")
               .getParent()
-              .resolve(workspaceName + ".xcodeproj");
+              .resolve(workspaceName + "-BUCK.xcodeproj");
     } else {
       outputDirectory = workspaceBuildTarget.getBasePath();
     }
@@ -381,7 +381,7 @@ public class WorkspaceAndProjectGenerator {
   private void writeWorkspaceMetaData(Path outputDirectory, String workspaceName)
       throws IOException {
     Path path =
-        combinedProject ? outputDirectory : outputDirectory.resolve(workspaceName + ".xcworkspace");
+        combinedProject ? outputDirectory : outputDirectory.resolve(workspaceName + "-BUCK.xcworkspace");
     rootCell.getFilesystem().mkdirs(path);
     ImmutableList<String> requiredTargetsStrings =
         getRequiredBuildTargets().stream()
@@ -1145,7 +1145,7 @@ public class WorkspaceAndProjectGenerator {
           pbxTargetToBuildTarget.get(project.getTargets().get(0));
       BuildTarget buildTarget = buildTargets.iterator().next();
       Path projectOutputDirectory =
-          buildTarget.getBasePath().resolve(project.getName() + ".xcodeproj");
+          buildTarget.getBasePath().resolve(project.getName() + "-BUCK.xcodeproj");
 
       SchemeGenerator schemeGenerator =
           buildSchemeGenerator(
@@ -1207,7 +1207,7 @@ public class WorkspaceAndProjectGenerator {
       Path schemeOutputDirectory =
           combinedProject
               ? outputDirectory
-              : outputDirectory.resolve(workspaceName + ".xcworkspace");
+              : outputDirectory.resolve(workspaceName + "-BUCK.xcworkspace");
 
       SchemeGenerator schemeGenerator =
           buildSchemeGenerator(

--- a/src/com/facebook/buck/features/apple/project/WorkspaceGenerator.java
+++ b/src/com/facebook/buck/features/apple/project/WorkspaceGenerator.java
@@ -173,7 +173,7 @@ class WorkspaceGenerator {
   }
 
   public Path getWorkspaceDir() {
-    return outputDirectory.resolve(workspaceName + ".xcworkspace");
+    return outputDirectory.resolve(workspaceName + "-BUCK.xcworkspace");
   }
 
   public Path writeWorkspace() throws IOException {

--- a/src/com/facebook/buck/features/apple/project/WorkspaceGenerator.java
+++ b/src/com/facebook/buck/features/apple/project/WorkspaceGenerator.java
@@ -268,6 +268,8 @@ class WorkspaceGenerator {
             + " \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n"
             + "<plist version=\"1.0\">\n"
             + "<dict>\n"
+            + "\t<key>BuildSystemType</key>\n"
+            + "\t<string>Original</string>\n"
             + "\t<key>IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded</key>\n"
             + "\t<false/>\n"
             + "</dict>\n"

--- a/src/com/facebook/buck/swift/SwiftBuckConfig.java
+++ b/src/com/facebook/buck/swift/SwiftBuckConfig.java
@@ -71,6 +71,10 @@ public class SwiftBuckConfig implements ConfigView<BuckConfig> {
     return delegate.getBooleanValue(SECTION_NAME, USE_FILELIST, false);
   }
 
+  public boolean getGenerateIndex() {
+    return delegate.getBooleanValue("project", "generate_index", false);
+  }
+
   public boolean getUseModulewrap() {
     return delegate.getBooleanValue(SECTION_NAME, USE_MODULEWRAP, false);
   }

--- a/src/com/facebook/buck/swift/SwiftCompile.java
+++ b/src/com/facebook/buck/swift/SwiftCompile.java
@@ -245,6 +245,8 @@ public class SwiftCompile extends AbstractBuildRuleWithDeclaredAndExtraDeps {
       compilerCommand.add("-o");
       String source = resolver.getRelativePath(sourcePath).toString();
       String file = Paths.get(source).getFileName().toString();
+      // Remove the file suffix from the file name
+      file = file.substring(0, file.lastIndexOf('.'));
       compilerCommand.add(outputPath.resolve(file + ".o").toString());
     }
 
@@ -367,6 +369,8 @@ public class SwiftCompile extends AbstractBuildRuleWithDeclaredAndExtraDeps {
         for (SourcePath sourcePath : srcs) {
           String source = resolver.getRelativePath(sourcePath).toString();
           String file = Paths.get(source).getFileName().toString();
+          // Remove the file suffix from the file name
+          file = file.substring(0, file.lastIndexOf('.'));
           command.add(outputPath.resolve(file + ".o").toString());
         }
 

--- a/src/com/facebook/buck/swift/SwiftCompile.java
+++ b/src/com/facebook/buck/swift/SwiftCompile.java
@@ -70,7 +70,6 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.io.PrintWriter;
 
-
 /** A build rule which compiles one or more Swift sources into a Swift module. */
 public class SwiftCompile extends AbstractBuildRuleWithDeclaredAndExtraDeps {
 
@@ -416,7 +415,6 @@ public class SwiftCompile extends AbstractBuildRuleWithDeclaredAndExtraDeps {
           command.add(outputPath.resolve(file + ".o").toString());
         }
 
-
         ProcessExecutorParams.Builder builder = ProcessExecutorParams.builder();
         builder.setCommand(command.build());
         return builder.build();
@@ -434,7 +432,7 @@ public class SwiftCompile extends AbstractBuildRuleWithDeclaredAndExtraDeps {
 
       @Override
       public String getShortName() {
-        return "combineObjectFiles";
+        return "combine object files";
       }
 
       @Override

--- a/src/com/facebook/buck/swift/SwiftCompile.java
+++ b/src/com/facebook/buck/swift/SwiftCompile.java
@@ -243,7 +243,7 @@ public class SwiftCompile extends AbstractBuildRuleWithDeclaredAndExtraDeps {
         "-num-threads",
         "12",
         "-index-store-path",
-        "."
+        "buck-out"
       );
 
       boolean use_output_filelist = false;

--- a/test/com/facebook/buck/features/apple/project/ProjectGeneratorTest.java
+++ b/test/com/facebook/buck/features/apple/project/ProjectGeneratorTest.java
@@ -171,7 +171,7 @@ public class ProjectGeneratorTest {
   private static final BuildRule RULE_1 = new EmptyFakeBuildRule(TARGET_1);
   private static final Path OUTPUT_DIRECTORY = Paths.get("_gen");
   private static final String PROJECT_NAME = "GeneratedProject";
-  private static final String PROJECT_CONTAINER = PROJECT_NAME + ".xcodeproj";
+  private static final String PROJECT_CONTAINER = PROJECT_NAME + "-BUCK.xcodeproj";
   private static final Path OUTPUT_PROJECT_BUNDLE_PATH =
       OUTPUT_DIRECTORY.resolve(PROJECT_CONTAINER);
   private static final Path OUTPUT_PROJECT_FILE_PATH =

--- a/test/com/facebook/buck/features/apple/project/ProjectGeneratorTest.java
+++ b/test/com/facebook/buck/features/apple/project/ProjectGeneratorTest.java
@@ -902,7 +902,11 @@ public class ProjectGeneratorTest {
     List<Path> headerSymlinkTrees = projectGenerator.getGeneratedHeaderSymlinkTrees();
     assertThat(headerSymlinkTrees, hasSize(2));
     assertEquals("buck-out/gen/_p/CwkbTNOBmb-pub", headerSymlinkTrees.get(0).toString());
-    assertTrue(projectFilesystem.isFile(headerSymlinkTrees.get(0).resolve("lib/lib.h")));
+
+    Path umbrellaHeaderPath = headerSymlinkTrees.get(0).resolve("lib/lib.h");
+    Optional<String> umbrellaContents = projectFilesystem.readFileIfItExists(umbrellaHeaderPath);
+    assertTrue(umbrellaContents.isPresent());
+    assertFalse(umbrellaContents.get().contains("lib-Swift.h"));
   }
 
   @Test


### PR DESCRIPTION
Add a new Buck config `project. generate_index`. When it's set to true, it invokes Swift Compiler with `-index-store-path` parameter to generate the index info during compilation.

To minimize the impact and reduce the risk, all the changes in this PR would only be triggered when the new `project. generate_index` config is enabled. And when we're using this modified version of Buck, we would run it without `generate_index` to build and debug the app, while running it another time in the background with `generate_index` to get the index info, and import it into Derived Data for Xcode.

@qyang-nj @shepting 
cc @bachand @dfed @fdiaz 