### PR TITLE
Xcode 11 fixes (linker search path)

### DIFF
--- a/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
+++ b/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
@@ -2508,7 +2508,7 @@ public class ProjectGenerator {
 
       librarySearchPaths.add("$DT_TOOLCHAIN_DIR/usr/lib/swift/$PLATFORM_NAME");
       if (options.shouldLinkSystemSwift()) {
-        librarySearchPaths.add("$DT_TOOLCHAIN_DIR/usr/lib/swift-5.0/$PLATFORM_NAME");
+        librarySearchPaths.add("$SDKROOT/usr/lib/swift");
       }
     }
 


### PR DESCRIPTION
[A recent commit](https://github.com/facebook/buck/commit/0b3b05cbaea065a1e75e9e4746f21a638d44dfb5) in `facebook/buck` addressed the linker search path problem for Xcode 11, but generated Xcode project build is still broken. This PR replaces `$DT_TOOLCHAIN_DIR/usr/lib/swift-5.0` with `/usr/lib/swift` for `LIBRARY_SEARCH_PATHS`, which fixes the broken generated Xcode build.

Please review: @xianwen @shepting 