### PR TITLE
Relative instead of absolute path for shorter build argument character count

### DIFF
--- a/src/com/facebook/buck/swift/SwiftCompile.java
+++ b/src/com/facebook/buck/swift/SwiftCompile.java
@@ -208,7 +208,7 @@ public class SwiftCompile extends AbstractBuildRuleWithDeclaredAndExtraDeps {
             getBuildDeps().stream()
                 .filter(SwiftCompile.class::isInstance)
                 .map(BuildRule::getSourcePathToOutput)
-                .map(input -> resolver.getAbsolutePath(input).toString())
+                .map(input -> resolver.getRelativePath(input).toString())
                 .collect(ImmutableSet.toImmutableSet())));
 
     boolean hasMainEntry =


### PR DESCRIPTION
This should help us shorten paths in our Swift build commands, which should enable us to make even more modules.

Late last week we found that some of our `swiftc` build commands were failing with the following exception:

> java.io.IOException: Cannot run program "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc" (in directory "/usr/local/var/buildkite-agent/builds/apps"): error=7, Argument list too long

This was happening because our `swiftc` commands were longer than [ARG_MAX](https://www.in-ulm.de/~mascheck/various/argmax/). The primary cause of our `swiftc` commands being so long was that we had more than 440 modules in our application target.

The argument list included many full paths to our modules, over and over again. This PR saves us approximately nineteen thousand characters in the length of the generated `swiftc` command, which gives us a bit of headroom (the total character limit is 262144 on the machines we use).