### PR TITLE
Add use_arg_file support for swift compiler

### DIFF
--- a/src/com/facebook/buck/swift/SwiftBuckConfig.java
+++ b/src/com/facebook/buck/swift/SwiftBuckConfig.java
@@ -34,6 +34,7 @@ public class SwiftBuckConfig implements ConfigView<BuckConfig> {
   public static final String PROJECT_ADD_AST_PATHS = "project_add_ast_paths";
   public static final String COPY_STDLIB_TO_FRAMEWORKS = "copy_stdlib_to_frameworks";
   public static final String EMIT_SWIFTDOCS = "emit_swiftdocs";
+  public static final String USE_ARG_FILE = "use_arg_file";
   private final BuckConfig delegate;
 
   @Override
@@ -69,6 +70,10 @@ public class SwiftBuckConfig implements ConfigView<BuckConfig> {
 
   public boolean getUseFileList() {
     return delegate.getBooleanValue(SECTION_NAME, USE_FILELIST, false);
+  }
+
+  public boolean getUseArgFile() {
+    return delegate.getBooleanValue(SECTION_NAME, USE_ARG_FILE, false);
   }
 
   public boolean getUseModulewrap() {

--- a/src/com/facebook/buck/swift/SwiftCompile.java
+++ b/src/com/facebook/buck/swift/SwiftCompile.java
@@ -82,6 +82,7 @@ public class SwiftCompile extends AbstractBuildRuleWithDeclaredAndExtraDeps {
   private final Path moduleObjectPath;
   private final ImmutableList<Path> objectPaths;
   private final Optional<Path> swiftFileListPath;
+  private final Optional<Path> argsFilePath;
 
   @AddToRuleKey private final boolean shouldEmitSwiftdocs;
   private final Path swiftdocPath;
@@ -150,6 +151,16 @@ public class SwiftCompile extends AbstractBuildRuleWithDeclaredAndExtraDeps {
                         BuildTargetPaths.getScratchPath(
                             getProjectFilesystem(), getBuildTarget(), "%s__filelist.txt")))
             : Optional.empty();
+
+    this.argsFilePath =
+      swiftBuckConfig.getUseArgFile()
+          ? Optional.of(
+            getProjectFilesystem()
+                .getRootPath()
+                .resolve(
+                    BuildTargetPaths.getScratchPath(
+                        getProjectFilesystem(), getBuildTarget(), "%s__swiftcompile.argsfile")))
+          : Optional.empty();
 
     this.shouldEmitSwiftdocs = swiftBuckConfig.getEmitSwiftdocs();
     this.swiftdocPath = outputPath.resolve(escapedModuleName + ".swiftdoc");
@@ -252,6 +263,7 @@ public class SwiftCompile extends AbstractBuildRuleWithDeclaredAndExtraDeps {
 
     ProjectFilesystem projectFilesystem = getProjectFilesystem();
     return new SwiftCompileStep(
+        projectFilesystem, argsFilePath,
         projectFilesystem.getRootPath(), ImmutableMap.of(), compilerCommand.build());
   }
 
@@ -304,6 +316,7 @@ public class SwiftCompile extends AbstractBuildRuleWithDeclaredAndExtraDeps {
 
     ProjectFilesystem projectFilesystem = getProjectFilesystem();
     return new SwiftCompileStep(
+        projectFilesystem, argsFilePath,
         projectFilesystem.getRootPath(), ImmutableMap.of(), compilerCommand.build());
   }
 

--- a/src/com/facebook/buck/swift/SwiftCompileStep.java
+++ b/src/com/facebook/buck/swift/SwiftCompileStep.java
@@ -18,14 +18,17 @@ package com.facebook.buck.swift;
 
 import com.facebook.buck.core.build.execution.context.ExecutionContext;
 import com.facebook.buck.core.util.log.Logger;
+import com.facebook.buck.io.filesystem.ProjectFilesystem;
 import com.facebook.buck.step.Step;
 import com.facebook.buck.step.StepExecutionResult;
 import com.facebook.buck.step.StepExecutionResults;
+import com.facebook.buck.util.Escaper;
 import com.facebook.buck.util.ProcessExecutor.Result;
 import com.facebook.buck.util.ProcessExecutorParams;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Map;
@@ -40,8 +43,17 @@ class SwiftCompileStep implements Step {
   private final ImmutableMap<String, String> compilerEnvironment;
   private final ImmutableList<String> compilerCommand;
 
+  private final ProjectFilesystem filesystem;
+  private final Optional<Path> argsFile;
+
   SwiftCompileStep(
-      Path compilerCwd, Map<String, String> compilerEnvironment, Iterable<String> compilerCommand) {
+      ProjectFilesystem filesystem,
+      Optional<Path> argsFile,
+      Path compilerCwd,
+      Map<String, String> compilerEnvironment,
+      Iterable<String> compilerCommand) {
+    this.filesystem = filesystem;
+    this.argsFile = argsFile;
     this.compilerCwd = compilerCwd;
     this.compilerEnvironment = ImmutableMap.copyOf(compilerEnvironment);
     this.compilerCommand = ImmutableList.copyOf(compilerCommand);
@@ -52,11 +64,24 @@ class SwiftCompileStep implements Step {
     return "swift compile";
   }
 
-  private ProcessExecutorParams makeProcessExecutorParams() {
+  private ProcessExecutorParams makeProcessExecutorParams() throws IOException {
     ProcessExecutorParams.Builder builder = ProcessExecutorParams.builder();
     builder.setDirectory(compilerCwd.toAbsolutePath());
     builder.setEnvironment(compilerEnvironment);
-    builder.setCommand(compilerCommand);
+
+    if (argsFile.isPresent()) {
+      filesystem.writeLinesToPath(
+        Iterables.transform(
+          compilerCommand.subList(1, compilerCommand.size()), Escaper.ARGFILE_ESCAPER::apply),
+          argsFile.get());
+      builder.setCommand(
+          ImmutableList.<String>builder()
+              .add(compilerCommand.get(0))
+              .add("@" + argsFile.get())
+              .build());
+    } else {
+      builder.setCommand(compilerCommand);
+    }
     return builder.build();
   }
 


### PR DESCRIPTION
Following #16, this PR adds support of using [response file](http://llvm.org/docs/CommandLine.html#response-files) (a.k.a argument file) for swift compiler. Theoretically this will allow us to have unlimited number of `apple_library`.

To use this feature, simply set `use_arg_file` to `true` under `swift` section in `.buckconfig`.
```
[swift]
  use_arg_file = true
```
 
Please note there are several ways to implement this. However,  some aspects are more important than others. **1)** The implementation needs to be consistent with [similar logic in CxxPreprocessAndCompileStep.java](https://github.com/airbnb/buck/blob/650777f599e188bcd53b915c3af0fcfa26c960c0/src/com/facebook/buck/cxx/CxxPreprocessAndCompileStep.java#L199).  **2)** The change should be as minimum as possible, so that we will be able to pull changes from `facebook/buck` in the future.
