### PR TITLE
[iOS] add output for junit xml format

### DIFF
--- a/src/com/facebook/buck/apple/XctoolRunTestsStep.java
+++ b/src/com/facebook/buck/apple/XctoolRunTestsStep.java
@@ -186,6 +186,7 @@ class XctoolRunTestsStep implements Step {
     this.command =
         createCommandArgs(
             xctoolPath,
+            outputPath.getParent().resolve("test-output.xml"), // junit output path
             sdkName,
             destinationSpecifier,
             logicTestBundlePaths,
@@ -478,6 +479,7 @@ class XctoolRunTestsStep implements Step {
 
   private static ImmutableList<String> createCommandArgs(
       Path xctoolPath,
+      Path junitOutputPath,
       String sdkName,
       Optional<String> destinationSpecifier,
       Collection<Path> logicTestBundlePaths,
@@ -488,6 +490,8 @@ class XctoolRunTestsStep implements Step {
     args.add(xctoolPath.toString());
     args.add("-reporter");
     args.add("json-stream");
+    args.add("-reporter");
+    args.add("junit:" + junitOutputPath);
     args.add("-sdk", sdkName);
     if (destinationSpecifier.isPresent()) {
       args.add("-destination");


### PR DESCRIPTION
`buck test` has an option `--xml` to generate xml report, but the report isn't the popular JUnit format. We need JUnit format to integrate with other systems (e.g. flaky tests detection). This PR allows `buck test` generates `test-output.xml` where the original `test-output.json` is.

Please review: @xianwen @shepting 