### PR TITLE
Supercharge Buck incremental build for Swift modules.

### DIFF
--- a/src/com/facebook/buck/apple/AppleLibraryDescription.java
+++ b/src/com/facebook/buck/apple/AppleLibraryDescription.java
@@ -885,7 +885,7 @@ public class AppleLibraryDescription
     BuildTarget swiftCompileTarget = baseTarget.withAppendedFlavors(Type.SWIFT_COMPILE.getFlavor());
     SwiftCompile compile = (SwiftCompile) graphBuilder.requireRule(swiftCompileTarget);
 
-    return CxxHeadersDir.of(CxxPreprocessables.IncludeType.LOCAL, compile.getOutputPath());
+    return CxxHeadersDir.of(CxxPreprocessables.IncludeType.LOCAL, compile.getSwiftModuleOutputPath());
   }
 
   private static CxxHeaders createSwiftObjcHeaders(

--- a/src/com/facebook/buck/swift/SwiftCompile.java
+++ b/src/com/facebook/buck/swift/SwiftCompile.java
@@ -24,6 +24,7 @@ import com.facebook.buck.core.model.impl.BuildTargetPaths;
 import com.facebook.buck.core.rulekey.AddToRuleKey;
 import com.facebook.buck.core.rules.BuildRule;
 import com.facebook.buck.core.rules.BuildRuleParams;
+import com.facebook.buck.core.rules.attr.SupportsInputBasedRuleKey;
 import com.facebook.buck.core.rules.impl.AbstractBuildRuleWithDeclaredAndExtraDeps;
 import com.facebook.buck.core.sourcepath.ExplicitBuildTargetSourcePath;
 import com.facebook.buck.core.sourcepath.SourcePath;
@@ -62,12 +63,14 @@ import com.google.common.collect.Streams;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.function.Function;
 
 /** A build rule which compiles one or more Swift sources into a Swift module. */
-public class SwiftCompile extends AbstractBuildRuleWithDeclaredAndExtraDeps {
+public class SwiftCompile extends AbstractBuildRuleWithDeclaredAndExtraDeps implements
+  SupportsInputBasedRuleKey {
 
   private static final String INCLUDE_FLAG = "-I";
 
@@ -470,5 +473,19 @@ public class SwiftCompile extends AbstractBuildRuleWithDeclaredAndExtraDeps {
    */
   public SourcePath getOutputPath() {
     return ExplicitBuildTargetSourcePath.of(getBuildTarget(), outputPath);
+  }
+
+  /**
+   * @return {@link SourcePath} to the .swiftmodule output from the compilation process. A
+   * swiftmodule file contains the public interface for a module, and is basically a binary file
+   * format equivalent to header files for a C framework or library.
+   *
+   * A swiftmodule file contains serialized ASTs (and possibly SIL), it conforms to
+   * Swift Binary Serialization Format, more details about this binary format can be found here:
+   * https://github.com/apple/swift/blob/master/docs/Serialization.rst.
+   */
+  public SourcePath getSwiftModuleOutputPath() {
+    return ExplicitBuildTargetSourcePath.of(getBuildTarget(),
+      Paths.get(outputPath.toString(), moduleName + ".swiftmodule"));
   }
 }

--- a/src/com/facebook/buck/swift/SwiftCompile.java
+++ b/src/com/facebook/buck/swift/SwiftCompile.java
@@ -482,7 +482,7 @@ public class SwiftCompile extends AbstractBuildRuleWithDeclaredAndExtraDeps impl
    *
    * A swiftmodule file contains serialized ASTs (and possibly SIL), it conforms to
    * Swift Binary Serialization Format, more details about this binary format can be found here:
-   * https://github.com/apple/swift/blob/master/docs/Serialization.rst.
+   * https://github.com/apple/swift/blob/7e6d62dae4bae4eb3737a6f76c0e51534c1bcca3/docs/Serialization.rst.
    */
   public SourcePath getSwiftModuleOutputPath() {
     return ExplicitBuildTargetSourcePath.of(getBuildTarget(),


### PR DESCRIPTION
## TL;DR;
Make SwiftCompile implement SupportsInputBasedRuleKey properly, to avoid unnecessary Swift recompile.

Verified in Buck Sample:
https://github.com/airbnb/BuckSample/pull/132

## How Buck calculates Rule Key
When Buck see a Build Target, it invoke `buildOrFetchFromCache` to build it or fetch the build result from cache.

https://github.com/airbnb/buck/blob/dabb3ca27da483fc3f756da87a789b7d542f96f7/src/com/facebook/buck/core/build/engine/impl/CachingBuildRuleBuilder.java#L973 

### 1. It first check the hash of everything that can directly or indirectly impact the output of this build target.

This step is done via `checkMatchingLocalKey`, which returns the build result from cache if the "Default Key", a Rule Key calculated by hashing everything that can directly or indirectly impact the output of this build target, remains unchanged.

https://github.com/airbnb/buck/blob/dabb3ca27da483fc3f756da87a789b7d542f96f7/src/com/facebook/buck/core/build/engine/impl/CachingBuildRuleBuilder.java#L981

This Default Key used here is calculated by "DefaultRuleKeyFactory"
https://github.com/airbnb/buck/blob/dabb3ca27da483fc3f756da87a789b7d542f96f7/src/com/facebook/buck/rules/keys/DefaultRuleKeyFactory.java#L117

**If a cache hit is found, the build result is retrieved from the cache and returned immediately.**

### 2. It then checks the hash of all the inputs of this build target, after all its dependencies had been built.

https://github.com/airbnb/buck/blob/dabb3ca27da483fc3f756da87a789b7d542f96f7/src/com/facebook/buck/core/build/engine/impl/CachingBuildRuleBuilder.java#L1038

However, this only applies for BuildRule classes that comply with `SupportsInputBasedRuleKey` interface:

https://github.com/airbnb/buck/blob/dabb3ca27da483fc3f756da87a789b7d542f96f7/src/com/facebook/buck/core/rules/attr/SupportsInputBasedRuleKey.java#L41

This time, the Rule Key is calculated by `InputBasedRuleKeyFactory`: https://github.com/airbnb/buck/blob/dabb3ca27da483fc3f756da87a789b7d542f96f7/src/com/facebook/buck/rules/keys/InputBasedRuleKeyFactory.java#L95

**This "InputBasedRuleKey" is calculated in a different way from the "DefaultRuleKey", that only the direct inputs of the BuildRule itself is considered.**

### How the Rule Key is calculated

Rule Key is calculated by going through every field in the "Build Rule" class with `AddToRuleKey` attribute. 

For fields of basic types like `String`, `Bool`, the hash can be done directly. For more complicated objects, like the `swiftCompiler` of the "SwiftCompile" class, this process is done recursively: the `RuleKeyFactory` will look into the `CommandTool` class, and iterate through all its fields with `AddToRuleKey` fields, and add them to hash according to the same rule.

https://github.com/airbnb/buck/blob/dabb3ca27da483fc3f756da87a789b7d542f96f7/src/com/facebook/buck/swift/SwiftCompile.java#L78

### How does `getSwiftModuleOutputPath` affect the Rule Key calculation

The `getSwiftModuleOutputPath` method created in this PR, exposes the `.swiftmodule` files from a module's Swift dependencies via `cxxDeps` property which has `AddToRuleKey` attribute:
https://github.com/airbnb/buck/blob/dabb3ca27da483fc3f756da87a789b7d542f96f7/src/com/facebook/buck/swift/SwiftCompile.java#L110

Before, this `cxxDeps` would include the whole `apple-swift-compile` output directory of the dependency module, which contains `-Swift.h` and `.o` in addition to `.swiftmodule`. By limiting the exposure to only `.swiftmodule`, we avoid unnecessary rebuild of dependent modules:

![image](https://user-images.githubusercontent.com/4402190/81845643-b575e900-9505-11ea-92e7-36ebf74ed066.png)

In the mean time, if any change happened to the `-Swift.h` or the `.hmap` file, the dependent module can still detect these changes and trigger a rebuild. Because both output are still included in the Rule Key calculation via `cxxDeps` using a different Flavor, `apple-swift-objc-generated-header`:

![image](https://user-images.githubusercontent.com/4402190/81846289-afccd300-9506-11ea-9ff4-19a03b2adfbe.png)


