### PR TITLE
Fix running Buck on BigSur (#24)

### DIFF
--- a/src/com/facebook/buck/util/environment/DefaultExecutionEnvironment.java
+++ b/src/com/facebook/buck/util/environment/DefaultExecutionEnvironment.java
@@ -75,7 +75,11 @@ public class DefaultExecutionEnvironment implements ExecutionEnvironment {
 
   @Override
   public Optional<String> getWifiSsid() {
-    return NetworkInfo.getWifiSsid();
+    return Optional.empty();
+    // The following fails on macOS Big Sur with error:
+    // "java.lang.NoClassDefFoundError: Could not initialize class com.facebook.buck.util.environment.MacWifiSsidFinder"
+    // So we return `Optional.empty()` instead to avoid this issue.
+    // return NetworkInfo.getWifiSsid();
   }
 
   @Override


### PR DESCRIPTION
We can't use the latest `airbnb-ios` branch directly on our BuckSample repo, because the `airbnb-ios` branch would add a `-buck` suffix to the generated workspace and break everything in the BuckSample repo.

So instead, I cherry picked the BigSur fix and merge it to the `ios` branch which BuckSample have been relying on instead.

@qyang-nj @shepting 