### PR TITLE
Fix xctest on Xcode 12.5

### DIFF
--- a/src/com/facebook/buck/apple/AppleTestDescription.java
+++ b/src/com/facebook/buck/apple/AppleTestDescription.java
@@ -83,6 +83,7 @@ import com.facebook.buck.io.BuildCellRelativePath;
 import com.facebook.buck.io.filesystem.ProjectFilesystem;
 import com.facebook.buck.rules.macros.AbsoluteOutputMacroExpander;
 import com.facebook.buck.rules.macros.LocationMacroExpander;
+import com.facebook.buck.rules.macros.StringWithMacros;
 import com.facebook.buck.rules.macros.StringWithMacrosConverter;
 import com.facebook.buck.step.Step;
 import com.facebook.buck.step.fs.MakeCleanDirectoryStep;
@@ -721,7 +722,7 @@ public class AppleTestDescription
               libraryTarget,
               params,
               graphBuilder,
-              args,
+              appendTestArgs(args),
               // For now, instead of building all deps as dylibs and fixing up their install_names,
               // we'll just link them statically.
               Optional.of(Linker.LinkableDepType.STATIC),
@@ -732,6 +733,20 @@ public class AppleTestDescription
       graphBuilder.computeIfAbsent(library.getBuildTarget(), ignored -> library);
     }
     return library;
+  }
+
+  private AppleTestDescriptionArg appendTestArgs(AppleTestDescriptionArg args) {
+    AppleTestDescriptionArg.Builder builder = AppleTestDescriptionArg.builder().from(args);
+
+    if (swiftBuckConfig.getAddXctestImportPaths()) {
+      // When importing XCTest in Swift, we will need to add the linker search paths to
+      // find libXCTestSupport.dylib and XCTest.framework.
+      builder.addLinkerFlags(
+        StringWithMacros.ofConstantString("-L$PLATFORM_DIR/Developer/usr/lib"),
+        StringWithMacros.ofConstantString("-F$PLATFORM_DIR/Developer/Library/Frameworks"));
+    }
+
+    return builder.build();
   }
 
   @Override

--- a/src/com/facebook/buck/swift/SwiftBuckConfig.java
+++ b/src/com/facebook/buck/swift/SwiftBuckConfig.java
@@ -35,6 +35,7 @@ public class SwiftBuckConfig implements ConfigView<BuckConfig> {
   public static final String COPY_STDLIB_TO_FRAMEWORKS = "copy_stdlib_to_frameworks";
   public static final String USE_LIPO_THIN = "use_lipo_thin";
   public static final String EMIT_SWIFTDOCS = "emit_swiftdocs";
+  public static final String ADD_XCTEST_IMPORT_PATHS = "add_xctest_import_paths";
   public static final String USE_ARG_FILE = "use_arg_file";
   public static final String ADD_AST_PATH = "add_ast_path";
   private final BuckConfig delegate;
@@ -134,5 +135,13 @@ public class SwiftBuckConfig implements ConfigView<BuckConfig> {
    */
   public boolean getEmitSwiftdocs() {
     return delegate.getBooleanValue(SECTION_NAME, EMIT_SWIFTDOCS, false);
+  }
+
+  /**
+   * If true, add -I$PLATFORM_DIR/Developer/usr/lib so that libXCTestSwiftSupport.dylib can be found
+   * at compile time.
+   */
+  public boolean getAddXctestImportPaths() {
+    return delegate.getBooleanValue(SECTION_NAME, ADD_XCTEST_IMPORT_PATHS, true);
   }
 }

--- a/src/com/facebook/buck/swift/SwiftLibraryDescription.java
+++ b/src/com/facebook/buck/swift/SwiftLibraryDescription.java
@@ -313,7 +313,8 @@ public class SwiftLibraryDescription
           args.getBridgingHeader(),
           preprocessor,
           cxxDeps,
-          false);
+          false,
+          swiftBuckConfig.getAddXctestImportPaths());
     }
 
     // Otherwise, we return the generic placeholder of this library.
@@ -484,7 +485,8 @@ public class SwiftLibraryDescription
         args.getBridgingHeader(),
         preprocessor,
         preprocessFlags,
-        importUnderlyingModule);
+        importUnderlyingModule,
+        swiftBuckConfig.getAddXctestImportPaths());
   }
 
   public static boolean isSwiftTarget(BuildTarget buildTarget) {


### PR DESCRIPTION
I took [the patch](https://github.com/yanks/buck/commit/801cbb8eca3792b3298996a1ece66d40310bd77b) from Jeffrey with some changes:
* fix merge conflicts
* delete test code (we are not running unit test for buck)
* remove the code of embedding test frameworks. They're not strictly needed and make buck incompatible between Xcode 12.4 and 12.5.

Please review:
@shepting 