### PR TITLE
Ignore the File Scrubbing error in Buck

### DIFF
--- a/src/com/facebook/buck/cxx/toolchain/objectfile/OsoSymbolsContentsScrubber.java
+++ b/src/com/facebook/buck/cxx/toolchain/objectfile/OsoSymbolsContentsScrubber.java
@@ -31,15 +31,17 @@ public class OsoSymbolsContentsScrubber implements FileContentsScrubber {
   }
 
   @Override
-  public void scrubFile(FileChannel file) throws IOException, ScrubException {
+  public void scrubFile(FileChannel file) throws IOException {
     if (!Machos.isMacho(file)) {
       return;
     }
     System.out.println(cellRootMap.toString());
-//    try {
-//      Machos.relativizeOsoSymbols(file, cellRootMap);
-//    } catch (Machos.MachoException e) {
-//      throw new ScrubException(e.getMessage());
-//    }
+    try {
+      Machos.relativizeOsoSymbols(file, cellRootMap);
+    } catch (Machos.MachoException e) {
+      // This is a known issue that happens when compiling iOS extensions on arm64 iphonesimulator.
+      System.err.println(e.getMessage());
+      System.err.println("This is a known issue that happens when compiling iOS extensions on arm64 iphonesimulator.");
+    }
   }
 }

--- a/src/com/facebook/buck/cxx/toolchain/objectfile/OsoSymbolsContentsScrubber.java
+++ b/src/com/facebook/buck/cxx/toolchain/objectfile/OsoSymbolsContentsScrubber.java
@@ -35,7 +35,6 @@ public class OsoSymbolsContentsScrubber implements FileContentsScrubber {
     if (!Machos.isMacho(file)) {
       return;
     }
-    System.out.println(cellRootMap.toString());
     try {
       Machos.relativizeOsoSymbols(file, cellRootMap);
     } catch (Machos.MachoException e) {

--- a/src/com/facebook/buck/cxx/toolchain/objectfile/OsoSymbolsContentsScrubber.java
+++ b/src/com/facebook/buck/cxx/toolchain/objectfile/OsoSymbolsContentsScrubber.java
@@ -35,10 +35,11 @@ public class OsoSymbolsContentsScrubber implements FileContentsScrubber {
     if (!Machos.isMacho(file)) {
       return;
     }
-    try {
-      Machos.relativizeOsoSymbols(file, cellRootMap);
-    } catch (Machos.MachoException e) {
-      throw new ScrubException(e.getMessage());
-    }
+    System.out.println(cellRootMap.toString());
+//    try {
+//      Machos.relativizeOsoSymbols(file, cellRootMap);
+//    } catch (Machos.MachoException e) {
+//      throw new ScrubException(e.getMessage());
+//    }
   }
 }


### PR DESCRIPTION
There is a known issue that `relativizeOsoSymbols` fails when compiling iOS extensions on arm64 iphonesimulator.

Initially, I tried to limit the ignoring of this exception to only "arm64 iphonesimulator iOS extensions". Unfortunately, we have very little information available in this function. To achieve that, we would need to expose the private variable "path" of `FileChannelImpl` and downcast the `FileChannel` variable to `FileChannelImpl`.

The change of this PR is a compromised solution, based on the fact that we have never seen the "ScrubException" error in the last 2 years we've been using Buck, so presumably this code path is reliable enough when it's not doing "arm64 iphonesimulator iOS extensions" and thus this error can be relatively safely ignore.

@shepting @qyang-nj 