### PR TITLE
Remove dot(.) from path in the .xcconfig

### DIFF
--- a/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
+++ b/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
@@ -3719,8 +3719,15 @@ public class ProjectGenerator {
   }
 
   private String getTargetOutputPath(TargetNode<?> targetNode) {
-    return Joiner.on('/')
-        .join("$BUILT_PRODUCTS_DIR", getBuiltProductsRelativeTargetOutputPath(targetNode));
+    String outputPath = getBuiltProductsRelativeTargetOutputPath(targetNode);
+    // The new build system on Xcode 12.5 does recognize path has a dot (.) in it, e.g `path/./dir`,
+    // so we handle it separately.
+    if (outputPath == ".") {
+      return "$BUILT_PRODUCTS_DIR";
+    } else {
+      return Joiner.on('/')
+        .join("$BUILT_PRODUCTS_DIR", outputPath);
+    }
   }
 
   @SuppressWarnings("unchecked")

--- a/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
+++ b/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
@@ -3725,8 +3725,7 @@ public class ProjectGenerator {
     if (outputPath == ".") {
       return "$BUILT_PRODUCTS_DIR";
     } else {
-      return Joiner.on('/')
-        .join("$BUILT_PRODUCTS_DIR", outputPath);
+      return Joiner.on('/').join("$BUILT_PRODUCTS_DIR", outputPath);
     }
   }
 


### PR DESCRIPTION
After switching to the New Build System of Xcode 12.5, we noticed a runtime crash on a test with host app. It's because Xcode doesn't like a dot(.) being the the path, like `path/./some_dir`. To fix this problem, we let buck not generate `.` in the paths in xcconfig files.

![image](https://user-images.githubusercontent.com/6559265/123886420-3d82a200-d904-11eb-8430-34b574f74bac.png)

**Please review**
@xianwen @shepting 